### PR TITLE
[Fix] Comply with device's minimal number of traps.

### DIFF
--- a/mis/pipeline/targets.py
+++ b/mis/pipeline/targets.py
@@ -36,6 +36,7 @@ class Pulse:
         self.pulse.draw()
 
 
+@dataclass
 class Register:
     """
     Specification of a geometry of atoms to be executed on a quantum device
@@ -52,10 +53,8 @@ class Register:
     register: pulser.Register
     graph: nx.Graph
 
-    def __init__(self, device: pulser.devices.Device, register: pulser.Register, graph: nx.Graph):
-        self.device = device
-        self.graph = graph
-        self.register = register.with_automatic_layout(device)
+    def __post_init__(self) -> None:
+        self.register = self.register.with_automatic_layout(self.device)
 
     def __len__(self) -> int:
         """

--- a/mis/pipeline/targets.py
+++ b/mis/pipeline/targets.py
@@ -36,7 +36,6 @@ class Pulse:
         self.pulse.draw()
 
 
-@dataclass
 class Register:
     """
     Specification of a geometry of atoms to be executed on a quantum device
@@ -52,6 +51,11 @@ class Register:
     device: pulser.devices.Device
     register: pulser.Register
     graph: nx.Graph
+
+    def __init__(self, device: pulser.devices.Device, register: pulser.Register, graph: nx.Graph):
+        self.device = device
+        self.graph = graph
+        self.register = register.with_automatic_layout(device)
 
     def __len__(self) -> int:
         """


### PR DESCRIPTION
For physical reasons, some devices expect a minimal number of traps. The easiest way to make sure that we always respect this constraint (and possibly others) is to call `register.with_automatic_layout`.
