### PR TITLE
[Fix] Infinite loop in preprocessing

### DIFF
--- a/mis/pipeline/kernelization.py
+++ b/mis/pipeline/kernelization.py
@@ -121,7 +121,7 @@ class Kernelization(BaseKernelization):
         Apply all rules, exhaustively, until the graph cannot be reduced
         further, storing the rules for rebuilding after the fact.
         """
-        while kernel_size_start := self.kernel.number_of_nodes() > 0:
+        while (kernel_size_start := self.kernel.number_of_nodes()) > 0:
             self.search_rule_isolated_node_removal()
             self.search_rule_twin_reduction()
             self.search_rule_node_fold()


### PR DESCRIPTION
Due to missing parens, `kernel_size_start` was a boolean. Consequently, `kernel_size_start - kernel_size_end` was never `0` and the loop continued forever.
