### PR TITLE
Implementing weighted preprocessing

### DIFF
--- a/mis/pipeline/fixtures.py
+++ b/mis/pipeline/fixtures.py
@@ -28,10 +28,10 @@ class Fixtures:
         self.config = config
         self.preprocessor: BasePreprocessor | None = None
         if self.config.preprocessor is not None:
-            self.preprocessor = self.config.preprocessor(instance.graph)
+            self.preprocessor = self.config.preprocessor(config, instance.graph)
         self.postprocessor: BasePostprocessor | None = None
         if self.config.postprocessor is not None:
-            self.postprocessor = self.config.postprocessor()
+            self.postprocessor = self.config.postprocessor(config)
 
     def preprocess(self) -> MISInstance:
         """

--- a/mis/pipeline/kernelization.py
+++ b/mis/pipeline/kernelization.py
@@ -1,23 +1,27 @@
 import abc
+import typing
 
 import networkx as nx
 from networkx.classes.reportviews import DegreeView
 from mis.pipeline.preprocessor import BasePreprocessor
 from mis.shared.graphs import is_independent
 
+if typing.TYPE_CHECKING:
+    from mis import SolverConfig
 
 class BaseKernelization(BasePreprocessor, abc.ABC):
     """
     Shared base class for kernelization.
     """
 
-    def __init__(self, graph: nx.Graph) -> None:
+    def __init__(self, config: SolverConfig, graph: nx.Graph) -> None:
         # The latest version of the graph.
         # We rewrite it progressively to decrease the number of
         # nodes and edges.
         self.kernel: nx.Graph = graph.copy()
         self.initial_number_of_nodes = self.kernel.number_of_nodes()
         self.rule_application_sequence: list[BaseRebuilder] = []
+        self.config = config
 
         # An index used to generate new node numbers.
         self._new_node_gen_counter: int = 1

--- a/mis/pipeline/maximization.py
+++ b/mis/pipeline/maximization.py
@@ -1,8 +1,13 @@
 import random
 import networkx as nx
+import typing
 
 from mis.pipeline.postprocessor import BasePostprocessor
-from mis.shared.types import MISSolution
+from mis.shared.types import MISSolution, Objective
+from mis.shared.graphs import BaseCostPicker
+
+if typing.TYPE_CHECKING:
+    from mis import SolverConfig
 
 
 class Maximization(BasePostprocessor):
@@ -16,6 +21,7 @@ class Maximization(BasePostprocessor):
 
     def __init__(
         self,
+        config: SolverConfig,
         frequency_threshold: float = 1e-7,
         augment_rounds: int = 10,
         seed: int = 0,
@@ -30,6 +36,8 @@ class Maximization(BasePostprocessor):
         self.frequency_threshold = frequency_threshold
         self.augment_rounds = augment_rounds
         self.seed = seed
+        self.objective = config.objective
+        self.picker = BaseCostPicker.for_objective(self.objective)
 
     def postprocess(self, solution: MISSolution) -> MISSolution | None:
         """
@@ -70,6 +78,7 @@ class Maximization(BasePostprocessor):
 
         # The best solution so far.
         best_pick = solution.node_indices
+        best_weight = self.picker.from_subgraph(solution.instance.graph, best_pick)
 
         rng = random.Random(self.seed)
         for _ in range(self.augment_rounds):
@@ -79,17 +88,23 @@ class Maximization(BasePostprocessor):
 
             # Attempt to grow the list of nodes in this order.
             picked = list(solution.node_indices)
+            weight = self.picker.from_subgraph(solution.instance.graph, picked)
             for node in order:
                 maybe_picked = list(picked)  # Copy the list.
                 maybe_picked.append(node)
                 if self.is_independent_list(graph=solution.instance.graph, nodes=maybe_picked):
                     # Commit our pick.
                     picked = maybe_picked
+                    weight += self.picker.from_node(solution.instance.graph.nodes[node])
 
             # Once we have picked as many nodes as possible, time to check whether
             # we have improved on the best solution.
-            if len(picked) > len(best_pick):
-                best_pick = picked
+            if self.objective == Objective.MAXIMIZE_WEIGHT:
+                if weight > best_weight:
+                    best_pick = picked
+            else:
+                if len(picked) > len(best_pick):
+                    best_pick = picked
         return MISSolution(
             instance=solution.instance,
             frequency=solution.frequency,

--- a/mis/shared/graphs.py
+++ b/mis/shared/graphs.py
@@ -28,7 +28,7 @@ class BaseWeightPicker(ABC):
 
     @classmethod
     @abstractmethod
-    def set_node_weight(cls, graph: nx.Graph, node: int, weight: float):
+    def set_node_weight(cls, graph: nx.Graph, node: int, weight: float) -> None:
         """
         Set the weight of a node.
 
@@ -71,14 +71,18 @@ class BaseWeightPicker(ABC):
         elif objective == Objective.MAXIMIZE_WEIGHT:
             return WeightedPicker
 
+
 class WeightedPicker(BaseWeightPicker):
     @classmethod
     def node_weight(cls, graph: nx.Graph, node: int) -> float:
-        return graph.nodes[node].get("weight", 1.0)
+        result = graph.nodes[node].get("weight", 1.0)
+        assert isinstance(result, float)
+        return result
 
     @classmethod
     def subgraph_weight(cls, graph: nx.Graph, nodes: list[int]) -> float:
         return float(sum(cls.node_weight(graph, n) for n in nodes))
+
 
 class UnweightedPicker(BaseWeightPicker):
     @classmethod
@@ -86,7 +90,7 @@ class UnweightedPicker(BaseWeightPicker):
         return 1.0
 
     @classmethod
-    def set_node_weight(cls, graph: nx.Graph, node: int, weight: float):
+    def set_node_weight(cls, graph: nx.Graph, node: int, weight: float) -> None:
         raise NotImplementedError("UnweightedPicker does not support operation `set_node_weight`")
 
     @classmethod
@@ -101,6 +105,7 @@ def closed_neighborhood(graph: nx.Graph, node: int) -> list[int]:
     neighbours = list(graph.neighbors(node))
     neighbours.append(node)
     return neighbours
+
 
 def is_independent(graph: nx.Graph, nodes: list[int]) -> bool:
     """

--- a/mis/shared/types.py
+++ b/mis/shared/types.py
@@ -4,7 +4,7 @@ from enum import Enum
 from typing import Any
 import networkx
 import matplotlib.pyplot as plt
-from mis.shared.graphs import calculate_weight
+from mis.shared.graphs import WeightPicker
 
 
 class BackendType(str, Enum):
@@ -20,6 +20,21 @@ class BackendType(str, Enum):
 class MethodType(str, Enum):
     EAGER = "eager"
     GREEDY = "greedy"
+
+class Objective(str, Enum):
+    """
+    The objective of the solver.
+    """
+
+    MAXIMIZE_SIZE = "size"
+    """
+    Maximize the size of the independent set (in number of nodes).
+    """
+
+    MAXIMIZE_WEIGHT = "weight"
+    """
+    Maximize the weight of the independent set (using the `weight` property).
+    """
 
 
 class MISInstance:
@@ -147,7 +162,7 @@ class MISSolution:
 
         # Note: As of this writing, self.weight is still considered a work in progress, so we
         # leave it out of the documentation.
-        self.weight = calculate_weight(instance.graph, nodes)
+        self.weight = WeightPicker.from_subgraph(instance.graph, nodes)
 
     def draw(
         self,

--- a/mis/shared/types.py
+++ b/mis/shared/types.py
@@ -4,7 +4,6 @@ from enum import Enum
 from typing import Any
 import networkx
 import matplotlib.pyplot as plt
-from mis.shared.graphs import WeightPicker
 
 
 class BackendType(str, Enum):
@@ -162,7 +161,8 @@ class MISSolution:
 
         # Note: As of this writing, self.weight is still considered a work in progress, so we
         # leave it out of the documentation.
-        self.weight = WeightPicker.from_subgraph(instance.graph, nodes)
+        from mis.shared.graphs import BaseWeightPicker # Avoid cycles.
+        self.weight = BaseWeightPicker.for_objective(Objective.MAXIMIZE_WEIGHT).subgraph_weight(instance.graph, nodes)
 
     def draw(
         self,

--- a/mis/shared/types.py
+++ b/mis/shared/types.py
@@ -20,6 +20,7 @@ class MethodType(str, Enum):
     EAGER = "eager"
     GREEDY = "greedy"
 
+
 class Objective(str, Enum):
     """
     The objective of the solver.
@@ -161,8 +162,11 @@ class MISSolution:
 
         # Note: As of this writing, self.weight is still considered a work in progress, so we
         # leave it out of the documentation.
-        from mis.shared.graphs import BaseWeightPicker # Avoid cycles.
-        self.weight = BaseWeightPicker.for_objective(Objective.MAXIMIZE_WEIGHT).subgraph_weight(instance.graph, nodes)
+        from mis.shared.graphs import BaseWeightPicker  # Avoid cycles.
+
+        self.weight = BaseWeightPicker.for_objective(Objective.MAXIMIZE_WEIGHT).subgraph_weight(
+            instance.graph, nodes
+        )
 
     def draw(
         self,

--- a/mis/solver/solver.py
+++ b/mis/solver/solver.py
@@ -368,7 +368,8 @@ class GreedyMISSolver(BaseSolver):
                 for rem_sol in remainder_solutions:
                     combined_nodes = current_mis + rem_sol.nodes
                     if (best_solution is None) or (
-                        self.weight_picker.subgraph_weight(self.instance.graph, combined_nodes) > best_solution.weight
+                        self.weight_picker.subgraph_weight(self.instance.graph, combined_nodes)
+                        > best_solution.weight
                     ):
                         best_solution = MISSolution(
                             instance=instance, nodes=combined_nodes, frequency=1.0

--- a/mis/solver/solver.py
+++ b/mis/solver/solver.py
@@ -13,7 +13,7 @@ from mis.pipeline.targets import Pulse, Register
 from mis.pipeline.config import SolverConfig
 from mis.solver.greedymapping import GreedyMapping
 from mis.pipeline.layout import Layout
-from mis.shared.graphs import remove_neighborhood, BaseCostPicker
+from mis.shared.graphs import remove_neighborhood, BaseWeightPicker
 
 
 class MISSolver:
@@ -269,7 +269,7 @@ class GreedyMISSolver(BaseSolver):
 
         self.solver_factory = solver_factory
         self.layout = self._build_layout()
-        self.picker = BaseCostPicker.for_objective(config.objective)
+        self.weight_picker = BaseWeightPicker.for_objective(config.objective)
 
     def _build_layout(self) -> Layout:
         """
@@ -368,7 +368,7 @@ class GreedyMISSolver(BaseSolver):
                 for rem_sol in remainder_solutions:
                     combined_nodes = current_mis + rem_sol.nodes
                     if (best_solution is None) or (
-                        self.picker.subgraph_weight(self.instance.graph, combined_nodes) > best_solution.weight
+                        self.weight_picker.subgraph_weight(self.instance.graph, combined_nodes) > best_solution.weight
                     ):
                         best_solution = MISSolution(
                             instance=instance, nodes=combined_nodes, frequency=1.0
@@ -417,7 +417,7 @@ class GreedyMISSolver(BaseSolver):
         """
         G = nx.Graph()
         for logical, physical in mapping.items():
-            weight = self.picker.node_weight(graph.nodes[logical])
+            weight = self.weight_picker.node_weight(graph, logical)
             pos = self.layout.graph.nodes[physical].get("pos", (0, 0))
             G.add_node(physical, weight=weight, pos=pos)
 

--- a/mis/solver/solver.py
+++ b/mis/solver/solver.py
@@ -368,7 +368,7 @@ class GreedyMISSolver(BaseSolver):
                 for rem_sol in remainder_solutions:
                     combined_nodes = current_mis + rem_sol.nodes
                     if (best_solution is None) or (
-                        self.picker.from_subgraph(self.instance.graph, combined_nodes) > best_solution.weight
+                        self.picker.subgraph_weight(self.instance.graph, combined_nodes) > best_solution.weight
                     ):
                         best_solution = MISSolution(
                             instance=instance, nodes=combined_nodes, frequency=1.0
@@ -417,7 +417,7 @@ class GreedyMISSolver(BaseSolver):
         """
         G = nx.Graph()
         for logical, physical in mapping.items():
-            weight = self.picker.from_node(graph.nodes[logical])
+            weight = self.picker.node_weight(graph.nodes[logical])
             pos = self.layout.graph.nodes[physical].get("pos", (0, 0))
             G.add_node(physical, weight=weight, pos=pos)
 

--- a/tests/test_classical_mis.py
+++ b/tests/test_classical_mis.py
@@ -10,16 +10,19 @@ from mis.pipeline.config import SolverConfig
 from mis.shared.types import MethodType
 from mis.pipeline.kernelization import Kernelization
 from mis.pipeline.maximization import Maximization
+from mis.shared.types import Objective
 
 TEST_DIMACS_FILES_DIR = Path.cwd() / "tests/test_files/dimacs"
 
 
 @pytest.mark.flaky(max_runs=5)
 @pytest.mark.parametrize("sample", [(TEST_DIMACS_FILES_DIR / "a265032_1tc.32.txt", 32, 68, 12)])
-@pytest.mark.parametrize("preprocessor", [None, lambda graph: Kernelization(graph)])
+@pytest.mark.parametrize("preprocessor", [None, lambda config, graph: Kernelization(config, graph)])
+@pytest.mark.parametrize("objective", argvalues=[Objective.MAXIMIZE_SIZE, Objective.MAXIMIZE_WEIGHT])
 def test_for_dimacs_32_node_graph(
     sample: tuple[Path, int, int, int],
-    preprocessor: None | Callable[[nx.Graph], Kernelization],
+    preprocessor: None | Callable[[SolverConfig, nx.Graph], Kernelization],
+    objective: Objective,
 ) -> None:
     """
     Classical MIS solver for a standard graph benchmark dataset in DIMACS format.
@@ -32,14 +35,14 @@ def test_for_dimacs_32_node_graph(
     assert dataset.instance.graph.number_of_nodes() == num_nodes
     assert dataset.instance.graph.number_of_edges() == num_edges
 
-    config = SolverConfig(method=MethodType.EAGER, max_iterations=1, preprocessor=preprocessor)
+    config = SolverConfig(method=MethodType.EAGER, max_iterations=1, preprocessor=preprocessor, objective=objective)
 
     # Run the solver
     solver = MISSolver(dataset.instance, config)
     solutions = solver.solve().result()
 
     # Check the solution is genuinely an independent set.
-    kernel = Kernelization(graph=dataset.instance.original_graph)
+    kernel = Kernelization(config, graph=dataset.instance.original_graph)
     solution = solutions[0]
 
     # Is it an independent set?
@@ -56,10 +59,12 @@ def test_for_dimacs_32_node_graph(
 
 @pytest.mark.flaky(max_runs=5)
 @pytest.mark.parametrize("sample", [(TEST_DIMACS_FILES_DIR / "a265032_1dc.64.txt", 64, 543, 9)])
-@pytest.mark.parametrize("preprocessor", [None, lambda graph: Kernelization(graph)])
+@pytest.mark.parametrize("preprocessor", [None, lambda config, graph: Kernelization(config, graph)])
+@pytest.mark.parametrize("objective", argvalues=[Objective.MAXIMIZE_SIZE, Objective.MAXIMIZE_WEIGHT])
 def test_for_dimacs_64_node_graph(
     sample: tuple[Path, int, int, int],
-    preprocessor: None | Callable[[nx.Graph], Kernelization],
+    preprocessor: None | Callable[[SolverConfig, nx.Graph], Kernelization],
+    objective: Objective,
 ) -> None:
     """
     Classical MIS solver for a standard graph benchmark dataset in DIMACS format.
@@ -72,14 +77,14 @@ def test_for_dimacs_64_node_graph(
     assert dataset.instance.graph.number_of_nodes() == num_nodes
     assert dataset.instance.graph.number_of_edges() == num_edges
 
-    config = SolverConfig(method=MethodType.EAGER, max_iterations=1, preprocessor=preprocessor)
+    config = SolverConfig(method=MethodType.EAGER, max_iterations=1, preprocessor=preprocessor, objective=objective)
 
     # Run the solver
     solver = MISSolver(dataset.instance, config)
     solutions = solver.solve().result()
 
     # Check the solution is genuinely an independent set.
-    kernel = Kernelization(graph=dataset.instance.original_graph)
+    kernel = Kernelization(config, graph=dataset.instance.original_graph)
 
     solution = solutions[0]
 
@@ -95,11 +100,13 @@ def test_for_dimacs_64_node_graph(
         assert len(solution.nodes) == mis_size
 
 
-@pytest.mark.parametrize("preprocessor", [None, lambda graph: Kernelization(graph)])
-@pytest.mark.parametrize("postprocessor", [None, lambda: Maximization()])
+@pytest.mark.parametrize("postprocessor", argvalues=[None, lambda config: Maximization(config)])
+@pytest.mark.parametrize("preprocessor", [None, lambda config, graph: Kernelization(config, graph)])
+@pytest.mark.parametrize("objective", argvalues=[Objective.MAXIMIZE_SIZE, Objective.MAXIMIZE_WEIGHT])
 def test_empty_mis(
-    preprocessor: None | Callable[[nx.Graph], Kernelization],
-    postprocessor: None | Callable[[], Maximization],
+    preprocessor: None | Callable[[SolverConfig, nx.Graph], Kernelization],
+    postprocessor: None | Callable[[SolverConfig], Maximization],
+    objective: Objective,
 ) -> None:
     """
     Classical MIS solver should work with an empty graph.
@@ -110,6 +117,7 @@ def test_empty_mis(
         max_iterations=1,
         preprocessor=preprocessor,
         postprocessor=postprocessor,
+        objective=objective
     )
 
     # Create the MIS instance
@@ -122,11 +130,13 @@ def test_empty_mis(
     assert len(solutions) == 0
 
 
-@pytest.mark.parametrize("preprocessor", [None, lambda graph: Kernelization(graph)])
-@pytest.mark.parametrize("postprocessor", [None, lambda: Maximization()])
+@pytest.mark.parametrize("postprocessor", [None, lambda config: Maximization(config)])
+@pytest.mark.parametrize("preprocessor", [None, lambda config, graph: Kernelization(config, graph)])
+@pytest.mark.parametrize("objective", argvalues=[Objective.MAXIMIZE_SIZE, Objective.MAXIMIZE_WEIGHT])
 def test_disconnected_mis(
-    preprocessor: None | Callable[[nx.Graph], Kernelization],
-    postprocessor: None | Callable[[], Maximization],
+    preprocessor: None | Callable[[SolverConfig, nx.Graph], Kernelization],
+    postprocessor: None | Callable[[SolverConfig], Maximization],
+    objective: Objective,
 ) -> None:
     """
     Classical MIS solver should work with a graph without any edge.
@@ -141,6 +151,7 @@ def test_disconnected_mis(
         max_iterations=1,
         preprocessor=preprocessor,
         postprocessor=postprocessor,
+        objective=objective,
     )
 
     # Create the MIS instance
@@ -154,11 +165,13 @@ def test_disconnected_mis(
     assert len(solutions[0].nodes) == SIZE
 
 
-@pytest.mark.parametrize("preprocessor", [None, lambda graph: Kernelization(graph)])
-@pytest.mark.parametrize("postprocessor", [None, lambda: Maximization()])
+@pytest.mark.parametrize("postprocessor", [None, lambda config: Maximization(config)])
+@pytest.mark.parametrize("preprocessor", [None, lambda config, graph: Kernelization(config, graph)])
+@pytest.mark.parametrize("objective", argvalues=[Objective.MAXIMIZE_SIZE, Objective.MAXIMIZE_WEIGHT])
 def test_star_mis(
-    preprocessor: None | Callable[[nx.Graph], Kernelization],
-    postprocessor: None | Callable[[], Maximization],
+    preprocessor: None | Callable[[SolverConfig, nx.Graph], Kernelization],
+    postprocessor: None | Callable[[SolverConfig], Maximization],
+    objective: Objective,
 ) -> None:
     """
     Classical MIS solver should work with a star-shaped graph.
@@ -175,6 +188,7 @@ def test_star_mis(
         max_iterations=1,
         preprocessor=preprocessor,
         postprocessor=postprocessor,
+        objective=objective
     )
 
     # Create the MIS instance
@@ -204,12 +218,14 @@ def test_star_mis(
         (TEST_DIMACS_FILES_DIR / "hexagon.txt", 6, 6, 3),
     ],
 )
-@pytest.mark.parametrize("preprocessor", [None, lambda graph: Kernelization(graph)])
-@pytest.mark.parametrize("postprocessor", [None, lambda: Maximization()])
+@pytest.mark.parametrize("postprocessor", [None, lambda config: Maximization(config)])
+@pytest.mark.parametrize("preprocessor", [None, lambda config, graph: Kernelization(config, graph)])
+@pytest.mark.parametrize("objective", argvalues=[Objective.MAXIMIZE_SIZE, Objective.MAXIMIZE_WEIGHT])
 def test_dimacs_mis(
     sample: tuple[Path, int, int, int],
-    preprocessor: None | Callable[[nx.Graph], Kernelization],
-    postprocessor: None | Callable[[], Maximization],
+    preprocessor: None | Callable[[SolverConfig, nx.Graph], Kernelization],
+    postprocessor: None | Callable[[SolverConfig], Maximization],
+    objective: Objective,
 ) -> None:
     """
     Test loading various graphs from DIMACS files and solving them.
@@ -225,6 +241,7 @@ def test_dimacs_mis(
         max_iterations=1,
         preprocessor=preprocessor,
         postprocessor=postprocessor,
+        objective=objective,
     )
 
     solver = MISSolver(dataset.instance, config)
@@ -235,7 +252,7 @@ def test_dimacs_mis(
     assert len(solutions) > 0
     for solution in solutions:
         # Is it an independent set?
-        kernel = Kernelization(dataset.instance.original_graph)
+        kernel = Kernelization(config, dataset.instance.original_graph)
         assert kernel.is_independent(solution.nodes)
         # Is it a subset of the original graph?
         for node in solution.nodes:

--- a/tests/test_classical_mis.py
+++ b/tests/test_classical_mis.py
@@ -18,7 +18,9 @@ TEST_DIMACS_FILES_DIR = Path.cwd() / "tests/test_files/dimacs"
 @pytest.mark.flaky(max_runs=5)
 @pytest.mark.parametrize("sample", [(TEST_DIMACS_FILES_DIR / "a265032_1tc.32.txt", 32, 68, 12)])
 @pytest.mark.parametrize("preprocessor", [None, lambda config, graph: Kernelization(config, graph)])
-@pytest.mark.parametrize("objective", argvalues=[Objective.MAXIMIZE_SIZE, Objective.MAXIMIZE_WEIGHT])
+@pytest.mark.parametrize(
+    "objective", argvalues=[Objective.MAXIMIZE_SIZE, Objective.MAXIMIZE_WEIGHT]
+)
 def test_for_dimacs_32_node_graph(
     sample: tuple[Path, int, int, int],
     preprocessor: None | Callable[[SolverConfig, nx.Graph], Kernelization],
@@ -35,7 +37,9 @@ def test_for_dimacs_32_node_graph(
     assert dataset.instance.graph.number_of_nodes() == num_nodes
     assert dataset.instance.graph.number_of_edges() == num_edges
 
-    config = SolverConfig(method=MethodType.EAGER, max_iterations=1, preprocessor=preprocessor, objective=objective)
+    config = SolverConfig(
+        method=MethodType.EAGER, max_iterations=1, preprocessor=preprocessor, objective=objective
+    )
 
     # Run the solver
     solver = MISSolver(dataset.instance, config)
@@ -60,7 +64,9 @@ def test_for_dimacs_32_node_graph(
 @pytest.mark.flaky(max_runs=5)
 @pytest.mark.parametrize("sample", [(TEST_DIMACS_FILES_DIR / "a265032_1dc.64.txt", 64, 543, 9)])
 @pytest.mark.parametrize("preprocessor", [None, lambda config, graph: Kernelization(config, graph)])
-@pytest.mark.parametrize("objective", argvalues=[Objective.MAXIMIZE_SIZE, Objective.MAXIMIZE_WEIGHT])
+@pytest.mark.parametrize(
+    "objective", argvalues=[Objective.MAXIMIZE_SIZE, Objective.MAXIMIZE_WEIGHT]
+)
 def test_for_dimacs_64_node_graph(
     sample: tuple[Path, int, int, int],
     preprocessor: None | Callable[[SolverConfig, nx.Graph], Kernelization],
@@ -77,7 +83,9 @@ def test_for_dimacs_64_node_graph(
     assert dataset.instance.graph.number_of_nodes() == num_nodes
     assert dataset.instance.graph.number_of_edges() == num_edges
 
-    config = SolverConfig(method=MethodType.EAGER, max_iterations=1, preprocessor=preprocessor, objective=objective)
+    config = SolverConfig(
+        method=MethodType.EAGER, max_iterations=1, preprocessor=preprocessor, objective=objective
+    )
 
     # Run the solver
     solver = MISSolver(dataset.instance, config)
@@ -94,7 +102,9 @@ def test_for_dimacs_64_node_graph(
     for node in solution.nodes:
         assert node in dataset.instance.node_label_to_index
     # Is it as good as we hope?
-    if preprocessor is None:
+    if preprocessor is None or objective == Objective.MAXIMIZE_WEIGHT:
+        # Note: As of this writing, the result we achieve with wMIS is not as good
+        # as the result we achieve with regular MIS. See issue #104.
         assert len(solution.nodes) <= mis_size
     else:
         assert len(solution.nodes) == mis_size
@@ -102,7 +112,9 @@ def test_for_dimacs_64_node_graph(
 
 @pytest.mark.parametrize("postprocessor", argvalues=[None, lambda config: Maximization(config)])
 @pytest.mark.parametrize("preprocessor", [None, lambda config, graph: Kernelization(config, graph)])
-@pytest.mark.parametrize("objective", argvalues=[Objective.MAXIMIZE_SIZE, Objective.MAXIMIZE_WEIGHT])
+@pytest.mark.parametrize(
+    "objective", argvalues=[Objective.MAXIMIZE_SIZE, Objective.MAXIMIZE_WEIGHT]
+)
 def test_empty_mis(
     preprocessor: None | Callable[[SolverConfig, nx.Graph], Kernelization],
     postprocessor: None | Callable[[SolverConfig], Maximization],
@@ -117,7 +129,7 @@ def test_empty_mis(
         max_iterations=1,
         preprocessor=preprocessor,
         postprocessor=postprocessor,
-        objective=objective
+        objective=objective,
     )
 
     # Create the MIS instance
@@ -132,7 +144,9 @@ def test_empty_mis(
 
 @pytest.mark.parametrize("postprocessor", [None, lambda config: Maximization(config)])
 @pytest.mark.parametrize("preprocessor", [None, lambda config, graph: Kernelization(config, graph)])
-@pytest.mark.parametrize("objective", argvalues=[Objective.MAXIMIZE_SIZE, Objective.MAXIMIZE_WEIGHT])
+@pytest.mark.parametrize(
+    "objective", argvalues=[Objective.MAXIMIZE_SIZE, Objective.MAXIMIZE_WEIGHT]
+)
 def test_disconnected_mis(
     preprocessor: None | Callable[[SolverConfig, nx.Graph], Kernelization],
     postprocessor: None | Callable[[SolverConfig], Maximization],
@@ -167,7 +181,9 @@ def test_disconnected_mis(
 
 @pytest.mark.parametrize("postprocessor", [None, lambda config: Maximization(config)])
 @pytest.mark.parametrize("preprocessor", [None, lambda config, graph: Kernelization(config, graph)])
-@pytest.mark.parametrize("objective", argvalues=[Objective.MAXIMIZE_SIZE, Objective.MAXIMIZE_WEIGHT])
+@pytest.mark.parametrize(
+    "objective", argvalues=[Objective.MAXIMIZE_SIZE, Objective.MAXIMIZE_WEIGHT]
+)
 def test_star_mis(
     preprocessor: None | Callable[[SolverConfig, nx.Graph], Kernelization],
     postprocessor: None | Callable[[SolverConfig], Maximization],
@@ -188,7 +204,7 @@ def test_star_mis(
         max_iterations=1,
         preprocessor=preprocessor,
         postprocessor=postprocessor,
-        objective=objective
+        objective=objective,
     )
 
     # Create the MIS instance
@@ -220,7 +236,9 @@ def test_star_mis(
 )
 @pytest.mark.parametrize("postprocessor", [None, lambda config: Maximization(config)])
 @pytest.mark.parametrize("preprocessor", [None, lambda config, graph: Kernelization(config, graph)])
-@pytest.mark.parametrize("objective", argvalues=[Objective.MAXIMIZE_SIZE, Objective.MAXIMIZE_WEIGHT])
+@pytest.mark.parametrize(
+    "objective", argvalues=[Objective.MAXIMIZE_SIZE, Objective.MAXIMIZE_WEIGHT]
+)
 def test_dimacs_mis(
     sample: tuple[Path, int, int, int],
     preprocessor: None | Callable[[SolverConfig, nx.Graph], Kernelization],

--- a/tests/test_greedy_mis.py
+++ b/tests/test_greedy_mis.py
@@ -11,19 +11,25 @@ from mis.shared.types import MethodType, Objective
 from mis.shared.graphs import is_independent
 
 
-@pytest.mark.parametrize("objective", argvalues=[Objective.MAXIMIZE_SIZE, Objective.MAXIMIZE_WEIGHT])
+@pytest.mark.parametrize(
+    "objective", argvalues=[Objective.MAXIMIZE_SIZE, Objective.MAXIMIZE_WEIGHT]
+)
 @pytest.mark.parametrize("use_quantum", [False, True])
 def test_greedy_mis_basic(
     simple_graph: nx.Graph,
     use_quantum: bool,
     objective: Objective,
-    ) -> None:
+) -> None:
     """
     Test Greedy MIS solver in both classical and quantum modes with default settings.
     """
     backend = QutipBackend() if use_quantum else None
     config = SolverConfig(
-        method=MethodType.GREEDY, use_quantum=use_quantum, backend=backend, objective=objective, greedy=GreedyConfig()
+        method=MethodType.GREEDY,
+        use_quantum=use_quantum,
+        backend=backend,
+        objective=objective,
+        greedy=GreedyConfig(),
     )
     instance = MISInstance(simple_graph)
     solver = MISSolver(instance, config)
@@ -36,7 +42,9 @@ def test_greedy_mis_basic(
 
 @pytest.mark.parametrize("preprocessor", [None, lambda config, graph: Kernelization(config, graph)])
 @pytest.mark.parametrize("postprocessor", argvalues=[None, lambda config: Maximization(config)])
-@pytest.mark.parametrize("objective", argvalues=[Objective.MAXIMIZE_SIZE, Objective.MAXIMIZE_WEIGHT])
+@pytest.mark.parametrize(
+    "objective", argvalues=[Objective.MAXIMIZE_SIZE, Objective.MAXIMIZE_WEIGHT]
+)
 @pytest.mark.parametrize("use_quantum", [False, True])
 def test_greedy_solver_with_pre_post(
     preprocessor: None | Callable[[SolverConfig, nx.Graph], Kernelization],
@@ -83,7 +91,9 @@ def test_greedy_solver_with_pre_post(
         assert is_independent(instance.graph, solution.nodes)
 
 
-@pytest.mark.parametrize("objective", argvalues=[Objective.MAXIMIZE_SIZE, Objective.MAXIMIZE_WEIGHT])
+@pytest.mark.parametrize(
+    "objective", argvalues=[Objective.MAXIMIZE_SIZE, Objective.MAXIMIZE_WEIGHT]
+)
 @pytest.mark.parametrize("use_quantum", [False, True])
 def test_greedy_mis_long(complex_graph: nx.Graph, use_quantum: bool, objective: Objective) -> None:
     """

--- a/tests/test_kernelization.py
+++ b/tests/test_kernelization.py
@@ -7,8 +7,9 @@ import mis.pipeline.kernelization as ker
 from mis.shared.types import Objective
 import networkx as nx
 
+
 @pytest.mark.parametrize("objective", [Objective.MAXIMIZE_SIZE, Objective.MAXIMIZE_WEIGHT])
-def test_is_subclique(objective) -> None:
+def test_is_subclique(objective: Objective) -> None:
     """
     Test clique detection with Kernlizer.is_subclique.
     """
@@ -83,6 +84,7 @@ K3_CLAW.add_nodes_from(range(6))
 K3_CLAW.add_edges_from([(0, 1), (0, 2), (1, 2), (2, 3), (4, 3), (5, 3)])
 # ------------------------------UNWEIGHTED TESTS--------------------------------------
 
+
 @pytest.mark.parametrize("objective", [Objective.MAXIMIZE_SIZE, Objective.MAXIMIZE_WEIGHT])
 def test_apply_rule_isolated_node_removal(objective: Objective) -> None:
     test_instance = ker.Kernelization(SolverConfig(objective=objective), graph_isolated)._kernelizer
@@ -105,7 +107,9 @@ def test_search_rule_isolated_node_removal(objective: Objective) -> None:
 
 @pytest.mark.parametrize("objective", [Objective.MAXIMIZE_SIZE, Objective.MAXIMIZE_WEIGHT])
 def test_folding_uw(objective: Objective) -> None:
-    test_instance = ker.Kernelization(SolverConfig(objective=objective), graph=graph_folding)._kernelizer
+    test_instance = ker.Kernelization(
+        SolverConfig(objective=objective), graph=graph_folding
+    )._kernelizer
     test_instance.fold_three(0, 1, 2, 9)
     assert not all(test_instance.kernel.has_node(node) for node in [0, 1, 2])
     assert all(test_instance.kernel.has_node(node) for node in [9, 3, 4, 5, 6, 7, 8])
@@ -113,10 +117,10 @@ def test_folding_uw(objective: Objective) -> None:
 
 @pytest.mark.parametrize("objective", [Objective.MAXIMIZE_SIZE, Objective.MAXIMIZE_WEIGHT])
 def test_apply_rule_node_fold_uw(objective: Objective) -> None:
-    test_instance = ker.Kernelization(SolverConfig(objective=objective), graph=graph_folding)._kernelizer
-    test_instance.apply_rule_node_fold(v=0, w_v=1.0,
-                                       u=1,w_u=1.0,
-                                       x=2, w_x=1.0)
+    test_instance = ker.Kernelization(
+        SolverConfig(objective=objective), graph=graph_folding
+    )._kernelizer
+    test_instance.apply_rule_node_fold(v=0, w_v=1.0, u=1, w_u=1.0, x=2, w_x=1.0)
     assert not all(test_instance.kernel.has_node(node) for node in [0, 1, 2])
     assert all(test_instance.kernel.has_node(node) for node in [9, 3, 4, 5, 6, 7, 8])
     mis_1 = test_instance.rebuild({9})
@@ -127,7 +131,9 @@ def test_apply_rule_node_fold_uw(objective: Objective) -> None:
 
 @pytest.mark.parametrize("objective", [Objective.MAXIMIZE_SIZE, Objective.MAXIMIZE_WEIGHT])
 def test_rule_node_fold(objective: Objective) -> None:
-    test_instance = ker.Kernelization(SolverConfig(objective=objective), graph=graph_folding)._kernelizer
+    test_instance = ker.Kernelization(
+        SolverConfig(objective=objective), graph=graph_folding
+    )._kernelizer
     test_instance.search_rule_node_fold()
     assert not all(test_instance.kernel.has_node(node) for node in [0, 1, 2])
     assert all(test_instance.kernel.has_node(node) for node in [9, 3, 4, 5, 6, 7, 8])
@@ -141,11 +147,24 @@ def test_aux_search_confinement() -> None:
     # This operation exists only on unweighted kernelization.
     objective = Objective.MAXIMIZE_SIZE
     test_instance = ker.UnweightedKernelization(SolverConfig(objective=objective), graph=P_3)
-    assert test_instance.aux_search_confinement({1}, {0}) == (1, 1, {2})
-    assert test_instance.aux_search_confinement({1}, {0, 2}) == (-1, 5, set())
-    assert test_instance.aux_search_confinement({2}, {0, 1}) == (2, 0, set())
+    confinement_1 = test_instance.aux_search_confinement({1}, {0})
+    assert confinement_1 is not None
+    assert confinement_1.node == 1
+    assert confinement_1.set_diff == {2}
+
+    confinement_2 = test_instance.aux_search_confinement({1}, {0, 2})
+    assert confinement_2 is None
+
+    confinement_3 = test_instance.aux_search_confinement({2}, {0, 1})
+    assert confinement_3 is not None
+    assert confinement_3.node == 2
+    assert confinement_3.set_diff == set()
+
     test_instance_2 = ker.UnweightedKernelization(SolverConfig(objective=objective), graph=CLAW)
-    assert test_instance_2.aux_search_confinement({1}, {0}) == (1, 2, {2, 3})
+    confinement_4 = test_instance_2.aux_search_confinement({1}, {0})
+    assert confinement_4 is not None
+    assert confinement_4.node == 1
+    assert confinement_4.set_diff == {2, 3}
 
 
 def test_apply_rule_unconfined() -> None:
@@ -175,9 +194,12 @@ def test_search_rule_unconfined_and_diamond() -> None:
     test_instance.search_rule_unconfined_and_diamond()
     assert set(test_instance.kernel) == {2, 4, 5}
 
+
 @pytest.mark.parametrize("objective", [Objective.MAXIMIZE_SIZE, Objective.MAXIMIZE_WEIGHT])
 def test_fold_twin_uw(objective: Objective) -> None:
-    test_instance = ker.Kernelization(SolverConfig(objective=objective), graph=K23_CLAW_bis)._kernelizer
+    test_instance = ker.Kernelization(
+        SolverConfig(objective=objective), graph=K23_CLAW_bis
+    )._kernelizer
     test_instance.fold_twin(0, 1, 10, [2, 3, 4])
     assert not all(test_instance.kernel.has_node(node) for node in [0, 1, 2, 3, 4])
     assert all(test_instance.kernel.has_node(node) for node in [10, 5, 6])
@@ -187,15 +209,23 @@ def test_fold_twin_uw(objective: Objective) -> None:
 
 @pytest.mark.parametrize("objective", [Objective.MAXIMIZE_SIZE, Objective.MAXIMIZE_WEIGHT])
 def test_find_twin(objective: Objective) -> None:
-    test_instance = ker.Kernelization(SolverConfig(objective=objective), graph=K23_CLAW_bis)._kernelizer
-    assert test_instance.find_twin(0) == "INDEPENDENT"
-    test_instance2 = ker.Kernelization(SolverConfig(objective=objective), graph=K23_CLAW_twin_linked)._kernelizer
+    test_instance = ker.Kernelization(
+        SolverConfig(objective=objective), graph=K23_CLAW_bis
+    )._kernelizer
+    twin_1 = test_instance.find_twin(0)
+    assert twin_1 is not None
+    assert twin_1.category == "INDEPENDENT"
+    test_instance2 = ker.Kernelization(
+        SolverConfig(objective=objective), graph=K23_CLAW_twin_linked
+    )._kernelizer
     assert test_instance2.find_twin(0) is None
 
 
 @pytest.mark.parametrize("objective", [Objective.MAXIMIZE_SIZE, Objective.MAXIMIZE_WEIGHT])
 def test_apply_rule_twin_ind(objective: Objective) -> None:
-    test_instance = ker.Kernelization(SolverConfig(objective=objective), graph=K23_CLAW_bis)._kernelizer
+    test_instance = ker.Kernelization(
+        SolverConfig(objective=objective), graph=K23_CLAW_bis
+    )._kernelizer
     test_instance.apply_rule_twin_independent(0, 1, [2, 3, 4])
     assert set(test_instance.kernel.nodes()) == {5, 6, 7}
     mis_1 = test_instance.rebuild({7})
@@ -206,7 +236,9 @@ def test_apply_rule_twin_ind(objective: Objective) -> None:
 
 @pytest.mark.parametrize("objective", [Objective.MAXIMIZE_SIZE, Objective.MAXIMIZE_WEIGHT])
 def test_apply_rule_twin_not_ind(objective: Objective) -> None:
-    test_instance = ker.Kernelization(SolverConfig(objective=objective), graph=K23_CLAW_N_linked)._kernelizer
+    test_instance = ker.Kernelization(
+        SolverConfig(objective=objective), graph=K23_CLAW_N_linked
+    )._kernelizer
     test_instance.apply_rule_twins_in_solution(0, 1, [2, 3, 4])
     assert set(test_instance.kernel.nodes()) == {5, 6}
     mis_1 = test_instance.rebuild(set())
@@ -215,14 +247,18 @@ def test_apply_rule_twin_not_ind(objective: Objective) -> None:
 
 @pytest.mark.parametrize("objective", [Objective.MAXIMIZE_SIZE, Objective.MAXIMIZE_WEIGHT])
 def test_search_rule_twin_reduction(objective: Objective) -> None:
-    test_instance = ker.Kernelization(SolverConfig(objective=objective), graph=K23_CLAW_bis)._kernelizer
+    test_instance = ker.Kernelization(
+        SolverConfig(objective=objective), graph=K23_CLAW_bis
+    )._kernelizer
     test_instance.search_rule_twin_reduction()
     assert set(test_instance.kernel.nodes()) == {5, 6, 7}
     mis_1 = test_instance.rebuild({7})
     assert mis_1 == {2, 3, 4}
     mis_2 = test_instance.rebuild(set())
     assert mis_2 == {0, 1}
-    test_instance_2 = ker.Kernelization(SolverConfig(objective=objective), graph=K23_CLAW_N_linked)._kernelizer
+    test_instance_2 = ker.Kernelization(
+        SolverConfig(objective=objective), graph=K23_CLAW_N_linked
+    )._kernelizer
     test_instance_2.apply_rule_twins_in_solution(0, 1, [2, 3, 4])
     assert set(test_instance_2.kernel.nodes()) == {5, 6}
     mis_3 = test_instance_2.rebuild(set())

--- a/tests/test_kernelization.py
+++ b/tests/test_kernelization.py
@@ -168,12 +168,12 @@ def test_unconfined_loop() -> None:
     assert not test_instance_3.unconfined_loop(0, {0}, {1, 2, 3})
 
 
-@pytest.mark.parametrize("objective", [Objective.MAXIMIZE_SIZE, Objective.MAXIMIZE_WEIGHT])
-def test_search_rule_unconfined_and_diamond(objective: Objective) -> None:
-    test_instance = ker.Kernelization(SolverConfig(objective=objective), graph=K3_CLAW)._kernelizer
+def test_search_rule_unconfined_and_diamond() -> None:
+    # This operation exists only on unweighted kernelization.
+    objective = Objective.MAXIMIZE_SIZE
+    test_instance = ker.UnweightedKernelization(SolverConfig(objective=objective), graph=K3_CLAW)
     test_instance.search_rule_unconfined_and_diamond()
     assert set(test_instance.kernel) == {2, 4, 5}
-
 
 @pytest.mark.parametrize("objective", [Objective.MAXIMIZE_SIZE, Objective.MAXIMIZE_WEIGHT])
 def test_fold_twin_uw(objective: Objective) -> None:
@@ -188,7 +188,7 @@ def test_fold_twin_uw(objective: Objective) -> None:
 @pytest.mark.parametrize("objective", [Objective.MAXIMIZE_SIZE, Objective.MAXIMIZE_WEIGHT])
 def test_find_twin(objective: Objective) -> None:
     test_instance = ker.Kernelization(SolverConfig(objective=objective), graph=K23_CLAW_bis)._kernelizer
-    assert test_instance.find_twin(0) == 1
+    assert test_instance.find_twin(0) == "INDEPENDENT"
     test_instance2 = ker.Kernelization(SolverConfig(objective=objective), graph=K23_CLAW_twin_linked)._kernelizer
     assert test_instance2.find_twin(0) is None
 

--- a/tests/test_qutip_mis.py
+++ b/tests/test_qutip_mis.py
@@ -13,7 +13,9 @@ from mis.shared.types import MethodType, Objective
 
 @pytest.mark.parametrize("postprocessor", argvalues=[None, lambda config: Maximization(config)])
 @pytest.mark.parametrize("preprocessor", [None, lambda config, graph: Kernelization(config, graph)])
-@pytest.mark.parametrize("objective", argvalues=[Objective.MAXIMIZE_SIZE, Objective.MAXIMIZE_WEIGHT])
+@pytest.mark.parametrize(
+    "objective", argvalues=[Objective.MAXIMIZE_SIZE, Objective.MAXIMIZE_WEIGHT]
+)
 def test_empty_qtip_mis(
     preprocessor: None | Callable[[SolverConfig, nx.Graph], Kernelization],
     postprocessor: None | Callable[[SolverConfig], Maximization],
@@ -44,7 +46,9 @@ def test_empty_qtip_mis(
 
 @pytest.mark.parametrize("postprocessor", argvalues=[None, lambda config: Maximization(config)])
 @pytest.mark.parametrize("preprocessor", [None, lambda config, graph: Kernelization(config, graph)])
-@pytest.mark.parametrize("objective", argvalues=[Objective.MAXIMIZE_SIZE, Objective.MAXIMIZE_WEIGHT])
+@pytest.mark.parametrize(
+    "objective", argvalues=[Objective.MAXIMIZE_SIZE, Objective.MAXIMIZE_WEIGHT]
+)
 def test_disconnected_qtip_mis(
     preprocessor: None | Callable[[SolverConfig, nx.Graph], Kernelization],
     postprocessor: None | Callable[[SolverConfig], Maximization],
@@ -87,7 +91,9 @@ def test_disconnected_qtip_mis(
 
 @pytest.mark.parametrize("postprocessor", argvalues=[None, lambda config: Maximization(config)])
 @pytest.mark.parametrize("preprocessor", [None, lambda config, graph: Kernelization(config, graph)])
-@pytest.mark.parametrize("objective", argvalues=[Objective.MAXIMIZE_SIZE, Objective.MAXIMIZE_WEIGHT])
+@pytest.mark.parametrize(
+    "objective", argvalues=[Objective.MAXIMIZE_SIZE, Objective.MAXIMIZE_WEIGHT]
+)
 def test_star_qtip_mis(
     preprocessor: None | Callable[[SolverConfig, nx.Graph], Kernelization],
     postprocessor: None | Callable[[SolverConfig], Maximization],

--- a/tests/test_qutip_mis.py
+++ b/tests/test_qutip_mis.py
@@ -8,14 +8,16 @@ from mis.solver.solver import MISInstance, MISSolver
 from mis.pipeline.config import SolverConfig
 from mis.pipeline.kernelization import Kernelization
 from mis.pipeline.maximization import Maximization
-from mis.shared.types import MethodType
+from mis.shared.types import MethodType, Objective
 
 
-@pytest.mark.parametrize("preprocessor", [None, lambda graph: Kernelization(graph)])
-@pytest.mark.parametrize("postprocessor", [None, lambda: Maximization()])
+@pytest.mark.parametrize("postprocessor", argvalues=[None, lambda config: Maximization(config)])
+@pytest.mark.parametrize("preprocessor", [None, lambda config, graph: Kernelization(config, graph)])
+@pytest.mark.parametrize("objective", argvalues=[Objective.MAXIMIZE_SIZE, Objective.MAXIMIZE_WEIGHT])
 def test_empty_qtip_mis(
-    preprocessor: None | Callable[[nx.Graph], Kernelization],
-    postprocessor: None | Callable[[], Maximization],
+    preprocessor: None | Callable[[SolverConfig, nx.Graph], Kernelization],
+    postprocessor: None | Callable[[SolverConfig], Maximization],
+    objective: Objective,
 ) -> None:
     """
     Classical MIS solver should work on an empty graph.
@@ -27,6 +29,7 @@ def test_empty_qtip_mis(
         backend=QutipBackend(),
         preprocessor=preprocessor,
         postprocessor=postprocessor,
+        objective=objective,
     )
 
     # Create the MIS instance
@@ -39,11 +42,13 @@ def test_empty_qtip_mis(
     assert len(solutions) == 0
 
 
-@pytest.mark.parametrize("preprocessor", [None, lambda graph: Kernelization(graph)])
-@pytest.mark.parametrize("postprocessor", [None, lambda: Maximization()])
+@pytest.mark.parametrize("postprocessor", argvalues=[None, lambda config: Maximization(config)])
+@pytest.mark.parametrize("preprocessor", [None, lambda config, graph: Kernelization(config, graph)])
+@pytest.mark.parametrize("objective", argvalues=[Objective.MAXIMIZE_SIZE, Objective.MAXIMIZE_WEIGHT])
 def test_disconnected_qtip_mis(
-    preprocessor: None | Callable[[nx.Graph], Kernelization],
-    postprocessor: None | Callable[[], Maximization],
+    preprocessor: None | Callable[[SolverConfig, nx.Graph], Kernelization],
+    postprocessor: None | Callable[[SolverConfig], Maximization],
+    objective: Objective,
 ) -> None:
     """
     Classical MIS solver should work on a graph without any edge.
@@ -59,6 +64,7 @@ def test_disconnected_qtip_mis(
         backend=QutipBackend(),
         preprocessor=preprocessor,
         postprocessor=postprocessor,
+        objective=objective,
     )
 
     # Create the MIS instance
@@ -79,11 +85,13 @@ def test_disconnected_qtip_mis(
     assert found
 
 
-@pytest.mark.parametrize("preprocessor", [(None), (lambda graph: Kernelization(graph))])
-@pytest.mark.parametrize("postprocessor", [None, lambda: Maximization()])
+@pytest.mark.parametrize("postprocessor", argvalues=[None, lambda config: Maximization(config)])
+@pytest.mark.parametrize("preprocessor", [None, lambda config, graph: Kernelization(config, graph)])
+@pytest.mark.parametrize("objective", argvalues=[Objective.MAXIMIZE_SIZE, Objective.MAXIMIZE_WEIGHT])
 def test_star_qtip_mis(
-    preprocessor: None | Callable[[nx.Graph], Kernelization],
-    postprocessor: None | Callable[[], Maximization],
+    preprocessor: None | Callable[[SolverConfig, nx.Graph], Kernelization],
+    postprocessor: None | Callable[[SolverConfig], Maximization],
+    objective: Objective,
 ) -> None:
     """
     Classical MIS solver should work on a star-shaped graph.
@@ -101,6 +109,7 @@ def test_star_qtip_mis(
         backend=QutipBackend(),
         preprocessor=preprocessor,
         postprocessor=postprocessor,
+        objective=objective,
     )
 
     # Create the MIS instance


### PR DESCRIPTION
- We add an option `SolverConfig.objective` to determine whether we optimize for number of nodes or for weights;
- We port the GreedyMIS to use this new `objective`.
- We port the preprocessor to use this new `objective`.
- Taking the opportunity to add some documentation to the preprocessor.

At this stage, we're missing tests specifically dedicated to weighted MIS.