### PR TITLE
[Fix] Allow multiple solutions for preprocessing #135

### DIFF
--- a/mis/pipeline/fixtures.py
+++ b/mis/pipeline/fixtures.py
@@ -33,7 +33,7 @@ class Fixtures:
         if self.config.postprocessor is not None:
             self.postprocessor = self.config.postprocessor(config)
 
-    def preprocess(self) -> MISInstance:
+    def preprocess(self) -> list[MISInstance]:
         """
         Apply preprocessing steps to the MIS instance before solving.
 
@@ -41,9 +41,8 @@ class Fixtures:
             MISInstance: The processed or annotated instance.
         """
         if self.preprocessor is not None:
-            graph = self.preprocessor.preprocess()
-            return MISInstance(graph)
-        return self.instance
+            return [MISInstance(graph) for graph in self.preprocessor.preprocess()]
+        return [self.instance]
 
     def rebuild(self, solution: MISSolution) -> MISSolution:
         """


### PR DESCRIPTION
This PR is intended to solve #92 . 

As mentioned by @Yoric , the preprocessor doesn't notice that there are multiple possible solutions. In fact, by applying `apply_rule_isolated_node_removal`, preprocessor looks for the first isolated node then proceed to reduce the graph and return the solution; but it doesn't take into account other candidate nodes in the graph that might comply to the rule.

This fix may not be exhaustive as there might be other aspects to consider but should be enough for now.

