### PR TITLE
Letting rebuilders return more than one solution

### DIFF
--- a/mis/pipeline/fixtures.py
+++ b/mis/pipeline/fixtures.py
@@ -79,26 +79,18 @@ class Fixtures:
             list[MISSolution]: The cleaned or transformed solution.
         """
 
-        print(
-            "YORIC: postprocess starting with %s solutions, best length %s"
-            % (solutions, max([sol.size for sol in solutions]))
-        )
         # Start with postprocessing, to compensate for noise or rounding errors.
         if self.postprocessor is None:
-            print("YORIC: postprocessor is None")
             bag: dict[str, MISSolution] = {
                 self._solution_key(solution): solution for solution in solutions
             }
         else:
-            print("YORIC: postprocessor is set")
             bag = {}
             for solution in solutions:
                 processed = self.postprocessor.postprocess(solution)
                 if processed is None:
                     # Disregard solution.
-                    print("YORIC: disregarding solution")
                     continue
-                print("YORIC: expanded solution %s to %s" % (solution, processed))
                 key = self._solution_key(processed)
                 existing = bag.get(key)
                 if existing is None:
@@ -106,41 +98,25 @@ class Fixtures:
                 else:
                     # Deduplicate solution.
                     existing.frequency += processed.frequency
-        print(
-            "YORIC: postprocess done with %s solutions, best length %s"
-            % (bag.values(), max([sol.size for sol in bag.values()]))
-        )
 
         # Now, any remaining solution should be a valid (w)MIS. However,
         # these solutions may be valid only for preprocessed graphs.
         # Rebuild these into solutions on the original graph.
         old_bag = bag
         if self.preprocessor is None:
-            print("YORIC: preprocessor is None")
             bag = old_bag
         else:
-            print("YORIC: preprocessor is set")
             bag = {}
             for partial in old_bag.values():
                 for nodes in self.preprocessor.rebuild(frozenset(partial.nodes)):
-                    print(
-                        "YORIC: rebuilt a solution with size %s into a solution with size %s"
-                        % (partial.size, len(nodes))
-                    )
                     key = self._solution_key(nodes)
                     existing = bag.get(key)
                     if existing is None:
-                        print("YORIC: rebuilt solution is fresh")
                         bag[key] = MISSolution(
                             instance=self.instance, nodes=list(nodes), frequency=partial.frequency
                         )
                     else:
                         # Deduplicate solution.
-                        print("YORIC: rebuilt solution is old")
                         existing.frequency += partial.frequency
-        print(
-            "YORIC: preprocess rebuild done with %s solutions, best length %s"
-            % (bag.values(), max([sol.size for sol in bag.values()]))
-        )
 
         return list(bag.values())

--- a/mis/pipeline/fixtures.py
+++ b/mis/pipeline/fixtures.py
@@ -45,43 +45,73 @@ class Fixtures:
             return MISInstance(graph)
         return self.instance
 
-    def rebuild(self, solution: MISSolution) -> MISSolution:
+    def _solution_key(self, solution: MISSolution | list[int] | frozenset[int]) -> str:
         """
-        Apply any pending rebuild operations to convert solutions
-        on preprocessed graphs into solutions on the original graph.
-
-        Args:
-            solution (MISSolution): The raw solution from a solver.
-
-        Returns:
-            MISSolution: The cleaned or transformed solution.
+        Generate a signature key to deduplicate solutions.
         """
-        if self.preprocessor is None:
-            return solution
-        # If we have preprocessed the graph, we end up with a solution
-        # that only works for the preprocessed graph.
-        #
-        # At this stage, we need to call the preprocessor's rebuilder to
-        # expand this to a solution on the original graph.
-        nodes = self.preprocessor.rebuild(set(solution.nodes))
-        return MISSolution(instance=self.instance, nodes=list(nodes), frequency=solution.frequency)
+        if isinstance(solution, frozenset):
+            indices = list(solution)
+        elif isinstance(solution, MISSolution):
+            indices = solution.node_indices
+        else:
+            indices = solution
+        return f"{sorted(indices)}"
 
     def postprocess(self, solutions: list[MISSolution]) -> list[MISSolution]:
+        """
+        Apply postprocessing steps to the MIS instance after solving.
+
+        These postprocessing steps consist in:
+        - first, any explicit postprocessor we have setup in `config`, used e.g.
+            to compensate for noise
+        - second, any implicit postprocessors (aka rebuilders) previously registered
+            by the preprocessor to convert solutions on preprocessed graphs
+            into solutions on the original graph, executed in the reverse order
+            in which they were registered.
+
+        Note: Neither of the operations maintains the frequency. Past this point,
+            the frequency of a solution may end up being > 1.0.
+
+        Args:
+            solutions (MISSolution): The solutions returned by the quantum device.
+
+        Returns:
+            list[MISSolution]: The cleaned or transformed solution.
+        """
+
+        # Start with postprocessing, to compensate for noise or rounding errors.
         if self.postprocessor is None:
-            return solutions
+            bag: dict[str, MISSolution] = {self._solution_key(solution): solution for solution in solutions}
+        else:
+            bag = {}
+            for solution in solutions:
+                processed = self.postprocessor.postprocess(solution)
+                if processed is None:
+                    # Disregard solution.
+                    continue
+                # Deduplicate if necessary.
+                key = self._solution_key(solution)
+                existing = bag.get(key)
+                if existing is None:
+                    bag[key] = solution
+                else:
+                    existing.frequency += solution.frequency
 
-        # Run postprocessing.
-        postprocessed_solutions: dict[str, MISSolution] = {}
-        for solution in solutions:
-            processed_solution = self.postprocessor.postprocess(solution)
-            if processed_solution is None:
-                continue
-            key = f"{sorted(processed_solution.node_indices)}"  # This is a bit of a waste, we could have used bistrings.
-            previous = postprocessed_solutions.get(key)
-            if previous is None:
-                postprocessed_solutions[key] = processed_solution
-            else:
-                # Merge the two solutions.
-                previous.frequency += processed_solution.frequency
+        # Now, any remaining solution should be a valid (w)MIS. However,
+        # these solutions may be valid only for preprocessed graphs.
+        # Rebuild these into solutions on the original graph.
+        old_bag = bag
+        if self.preprocessor is None:
+            bag = old_bag
+        else:
+            bag = {}
+            for partial in old_bag.values():
+                for nodes in self.preprocessor.rebuild(frozenset(partial.nodes)):
+                    key = self._solution_key(nodes)
+                    existing = bag.get(key)
+                    if existing is None:
+                        bag[key] = MISSolution(instance=self.instance, nodes=list(nodes), frequency=partial.frequency)
+                    else:
+                        existing.frequency += partial.frequency
 
-        return list(postprocessed_solutions.values())
+        return list(bag.values())

--- a/mis/pipeline/fixtures.py
+++ b/mis/pipeline/fixtures.py
@@ -79,11 +79,16 @@ class Fixtures:
             list[MISSolution]: The cleaned or transformed solution.
         """
 
-        print("YORIC: postprocess starting with %s solutions, best length %s" % (solutions, max([sol.size for sol in solutions])))
+        print(
+            "YORIC: postprocess starting with %s solutions, best length %s"
+            % (solutions, max([sol.size for sol in solutions]))
+        )
         # Start with postprocessing, to compensate for noise or rounding errors.
         if self.postprocessor is None:
             print("YORIC: postprocessor is None")
-            bag: dict[str, MISSolution] = {self._solution_key(solution): solution for solution in solutions}
+            bag: dict[str, MISSolution] = {
+                self._solution_key(solution): solution for solution in solutions
+            }
         else:
             print("YORIC: postprocessor is set")
             bag = {}
@@ -91,15 +96,20 @@ class Fixtures:
                 processed = self.postprocessor.postprocess(solution)
                 if processed is None:
                     # Disregard solution.
+                    print("YORIC: disregarding solution")
                     continue
-                key = self._solution_key(solution)
+                print("YORIC: expanded solution %s to %s" % (solution, processed))
+                key = self._solution_key(processed)
                 existing = bag.get(key)
                 if existing is None:
-                    bag[key] = solution
+                    bag[key] = processed
                 else:
                     # Deduplicate solution.
-                    existing.frequency += solution.frequency
-        print("YORIC: postprocess done with %s solutions, best length %s" % ( bag.values(), max([sol.size for sol in bag.values()])))
+                    existing.frequency += processed.frequency
+        print(
+            "YORIC: postprocess done with %s solutions, best length %s"
+            % (bag.values(), max([sol.size for sol in bag.values()]))
+        )
 
         # Now, any remaining solution should be a valid (w)MIS. However,
         # these solutions may be valid only for preprocessed graphs.
@@ -113,16 +123,24 @@ class Fixtures:
             bag = {}
             for partial in old_bag.values():
                 for nodes in self.preprocessor.rebuild(frozenset(partial.nodes)):
-                    print("YORIC: rebuilt a solution with size %s into a solution with size %s" % (partial.size, len(nodes)))
+                    print(
+                        "YORIC: rebuilt a solution with size %s into a solution with size %s"
+                        % (partial.size, len(nodes))
+                    )
                     key = self._solution_key(nodes)
                     existing = bag.get(key)
                     if existing is None:
                         print("YORIC: rebuilt solution is fresh")
-                        bag[key] = MISSolution(instance=self.instance, nodes=list(nodes), frequency=partial.frequency)
+                        bag[key] = MISSolution(
+                            instance=self.instance, nodes=list(nodes), frequency=partial.frequency
+                        )
                     else:
                         # Deduplicate solution.
                         print("YORIC: rebuilt solution is old")
                         existing.frequency += partial.frequency
-        print("YORIC: preprocess rebuild done with %s solutions, best length %s" % (bag.values(), max([sol.size for sol in bag.values()])))
+        print(
+            "YORIC: preprocess rebuild done with %s solutions, best length %s"
+            % (bag.values(), max([sol.size for sol in bag.values()]))
+        )
 
         return list(bag.values())

--- a/mis/pipeline/kernelization.py
+++ b/mis/pipeline/kernelization.py
@@ -134,6 +134,7 @@ class BaseKernelization(BasePreprocessor, abc.ABC):
         """
         partial_solutions = [partial_solution]
         for rule_app in reversed(self.rule_application_sequence):
+            print("YORIC: rebuild %s in progress with %s solution, best length %s: %s" % (type(rule_app), len(partial_solutions), max([len(p) for p in partial_solutions]), partial_solutions))
             new_partial_solutions: list[frozenset[int]] = []
             for old_partial_solution in partial_solutions:
                 new_partial_solutions.extend(rule_app.rebuild(old_partial_solution))

--- a/mis/pipeline/kernelization.py
+++ b/mis/pipeline/kernelization.py
@@ -128,21 +128,12 @@ class BaseKernelization(BasePreprocessor, abc.ABC):
 
     def rebuild(self, partial_solution: frozenset[int]) -> list[frozenset[int]]:
         """
-        Rebuild a MIS solution to the original graph from
+        Rebuild one or more MIS solutions to the original graph from
         a partial MIS solution on the reduced graph obtained
         by kernelization.
         """
         partial_solutions = [partial_solution]
         for rule_app in reversed(self.rule_application_sequence):
-            print(
-                "YORIC: rebuild %s in progress with %s solution, best length %s: %s"
-                % (
-                    type(rule_app),
-                    len(partial_solutions),
-                    max([len(p) for p in partial_solutions]),
-                    partial_solutions,
-                )
-            )
             new_partial_solutions: list[frozenset[int]] = []
             for old_partial_solution in partial_solutions:
                 new_partial_solutions.extend(rule_app.rebuild(old_partial_solution))

--- a/mis/pipeline/kernelization.py
+++ b/mis/pipeline/kernelization.py
@@ -224,6 +224,7 @@ class BaseKernelization(BasePreprocessor, abc.ABC):
                 # We didn't find any rule to apply, time to stop.
                 logger.info("preprocessing - ran out of rules")
                 break
+        logger.info("preprocessing - complete")
         return self.kernel
 
     def add_rebuilder(self, rebuilder: "BaseRebuilder") -> None:

--- a/mis/pipeline/kernelization.py
+++ b/mis/pipeline/kernelization.py
@@ -134,7 +134,15 @@ class BaseKernelization(BasePreprocessor, abc.ABC):
         """
         partial_solutions = [partial_solution]
         for rule_app in reversed(self.rule_application_sequence):
-            print("YORIC: rebuild %s in progress with %s solution, best length %s: %s" % (type(rule_app), len(partial_solutions), max([len(p) for p in partial_solutions]), partial_solutions))
+            print(
+                "YORIC: rebuild %s in progress with %s solution, best length %s: %s"
+                % (
+                    type(rule_app),
+                    len(partial_solutions),
+                    max([len(p) for p in partial_solutions]),
+                    partial_solutions,
+                )
+            )
             new_partial_solutions: list[frozenset[int]] = []
             for old_partial_solution in partial_solutions:
                 new_partial_solutions.extend(rule_app.rebuild(old_partial_solution))

--- a/mis/pipeline/preprocessor.py
+++ b/mis/pipeline/preprocessor.py
@@ -26,7 +26,7 @@ class BasePreprocessor(abc.ABC):
     """
 
     @abc.abstractmethod
-    def rebuild(self, partial_solution: set[int]) -> set[int]: ...
+    def rebuild(self, partial_solution: frozenset[int]) -> list[frozenset[int]]: ...
 
     """
     Apply any pending rebuild operations.

--- a/mis/shared/graphs.py
+++ b/mis/shared/graphs.py
@@ -80,9 +80,7 @@ class BaseWeightPicker(ABC):
 class WeightedPicker(BaseWeightPicker):
     @classmethod
     def node_weight(cls, graph: nx.Graph, node: int) -> float:
-        result = graph.nodes[node].get("weight", 1.0)
-        assert isinstance(result, float)
-        return result
+        return float(graph.nodes[node].get("weight", 1.0))
 
     @classmethod
     def set_node_weight(cls, graph: nx.Graph, node: int, weight: float) -> None:

--- a/mis/shared/types.py
+++ b/mis/shared/types.py
@@ -216,3 +216,6 @@ class MISSolution:
             font (str): Font type
         """
         self.instance.draw(self.node_indices, node_size, highlight_color, font_family)
+
+    def __repr__(self) -> str:
+        return f"{self.nodes}: {self.frequency}"

--- a/mis/solver/solver.py
+++ b/mis/solver/solver.py
@@ -159,20 +159,13 @@ class MISSolverQuantum(BaseSolver):
                 )
                 for [bitstr, count] in data.items()
             ]
-            print("YORIC: solver starting with %s solutions" % (len(raw),))
 
         # Postprocess to get rid of quantum noise.
         solutions = self.fixtures.postprocess(raw)
-        print("YORIC: solver continuing with %s solutions" % (len(solutions),))
 
         # And present the most interesting solutions first.
         solutions.sort(key=lambda sol: sol.frequency, reverse=True)
-        cut = solutions[: self.config.max_number_of_solutions]
-        print(
-            "YORIC: solver cutting to %s solutions (max %s)"
-            % (len(cut), self.config.max_number_of_solutions)
-        )
-        return cut
+        return solutions[: self.config.max_number_of_solutions]
 
     def solve(self) -> list[MISSolution]:
         """

--- a/mis/solver/solver.py
+++ b/mis/solver/solver.py
@@ -100,7 +100,6 @@ class MISSolverClassical(BaseSolver):
             )
 
         solutions = self.fixtures.postprocess([partial_solution])
-        solutions = [self.fixtures.rebuild(sol) for sol in solutions]
         solutions.sort(key=lambda sol: sol.frequency, reverse=True)
 
         return solutions[: self.config.max_number_of_solutions]
@@ -149,7 +148,7 @@ class MISSolverQuantum(BaseSolver):
             # to whittle down the original graph to an empty graph. But we need at least one
             # partial solution to be able to rebuild an MIS, so we handle this edge
             # case by injecting an empty solution.
-            postprocessed = [MISSolution(instance=instance, frequency=1, nodes=[])]
+            solutions = [MISSolution(instance=instance, frequency=1, nodes=[])]
 
             # No noise here, since there wasn't any quantum measurement, so no
             # postprocessing.
@@ -165,14 +164,11 @@ class MISSolverQuantum(BaseSolver):
             ]
 
             # Postprocess to get rid of quantum noise.
-            postprocessed = self.fixtures.postprocess(raw)
-
-        # Then rebuild any partial solution into solutions on the full graph.
-        rebuilt = [self.fixtures.rebuild(r) for r in postprocessed]
+            solutions = self.fixtures.postprocess(raw)
 
         # And present the most interesting solutions first.
-        rebuilt.sort(key=lambda sol: sol.frequency, reverse=True)
-        return rebuilt[: self.config.max_number_of_solutions]
+        solutions.sort(key=lambda sol: sol.frequency, reverse=True)
+        return solutions[: self.config.max_number_of_solutions]
 
     def solve(self) -> list[MISSolution]:
         """

--- a/mis/solver/solver.py
+++ b/mis/solver/solver.py
@@ -159,16 +159,19 @@ class MISSolverQuantum(BaseSolver):
                 )
                 for [bitstr, count] in data.items()
             ]
-            print("YORIC: solver starting with %s solutions" % (len(raw), ))
+            print("YORIC: solver starting with %s solutions" % (len(raw),))
 
         # Postprocess to get rid of quantum noise.
         solutions = self.fixtures.postprocess(raw)
-        print("YORIC: solver continuing with %s solutions" % (len(solutions), ))
+        print("YORIC: solver continuing with %s solutions" % (len(solutions),))
 
         # And present the most interesting solutions first.
         solutions.sort(key=lambda sol: sol.frequency, reverse=True)
         cut = solutions[: self.config.max_number_of_solutions]
-        print("YORIC: solver cutting to %s solutions (max %s)" % (len(cut), self.config.max_number_of_solutions))
+        print(
+            "YORIC: solver cutting to %s solutions (max %s)"
+            % (len(cut), self.config.max_number_of_solutions)
+        )
         return cut
 
     def solve(self) -> list[MISSolution]:

--- a/tests/test_kernelization.py
+++ b/tests/test_kernelization.py
@@ -135,8 +135,8 @@ def test_apply_rule_isolated_node_removal(
     # We should have removed {0} and its neighborhood.
     assert not any(test_instance.kernel.has_node(node) for node in [0, 1])
     assert all(test_instance.kernel.has_node(node) for node in [2, 3, 4, 5])
-    test_mis = test_instance.rebuild({2})
-    assert test_mis == {0, 2}
+    test_mis = test_instance.rebuild(frozenset({2}))
+    assert test_mis == [frozenset({0, 2})]
 
 
 @pytest.mark.parametrize("weighting", [Weighting.UNWEIGHTED, Weighting.WEIGHTED])
@@ -155,8 +155,8 @@ def test_search_rule_isolated_node_removal(
         # {0} is isolated and maximal, so removing {0} and its neighborhood.
         assert not any(test_instance.kernel.has_node(node) for node in [0, 1])
         assert all(test_instance.kernel.has_node(node) for node in [2, 3, 4, 5])
-        test_mis = test_instance.rebuild({2})
-        assert test_mis == {0, 2}
+        test_mis = test_instance.rebuild(frozenset({2}))
+        assert test_mis == [frozenset({0, 2})]
 
 
 @pytest.mark.parametrize("weighting", [Weighting.UNWEIGHTED, Weighting.WEIGHTED])
@@ -177,10 +177,10 @@ def test_apply_rule_node_fold_uw(weighting: Weighting) -> None:
     test_instance.apply_rule_node_fold(v=0, w_v=1.0, u=1, w_u=1.0, x=2, w_x=1.0)
     assert not all(test_instance.kernel.has_node(node) for node in [0, 1, 2])
     assert all(test_instance.kernel.has_node(node) for node in [9, 3, 4, 5, 6, 7, 8])
-    mis_1 = test_instance.rebuild({9})
-    assert mis_1 == {1, 2}
-    mis_2 = test_instance.rebuild({4})
-    assert mis_2 == {0, 4}
+    mis_1 = test_instance.rebuild(frozenset({9}))
+    assert mis_1 == [frozenset({1, 2})]
+    mis_2 = test_instance.rebuild(frozenset({4}))
+    assert mis_2 == [frozenset({0, 4})]
 
 
 @pytest.mark.parametrize("weighting", [Weighting.UNWEIGHTED, Weighting.WEIGHTED])
@@ -191,10 +191,10 @@ def test_rule_node_fold(weighting: Weighting) -> None:
     test_instance.search_rule_node_fold()
     assert not all(test_instance.kernel.has_node(node) for node in [0, 1, 2])
     assert all(test_instance.kernel.has_node(node) for node in [9, 3, 4, 5, 6, 7, 8])
-    mis_1 = test_instance.rebuild({9})
-    assert mis_1 == {1, 2}
-    mis_2 = test_instance.rebuild({4})
-    assert mis_2 == {0, 4}
+    mis_1 = test_instance.rebuild(frozenset({9}))
+    assert mis_1 == [frozenset({1, 2})]
+    mis_2 = test_instance.rebuild(frozenset({4}))
+    assert mis_2 == [frozenset({0, 4})]
 
 
 def test_aux_search_confinement() -> None:
@@ -204,7 +204,7 @@ def test_aux_search_confinement() -> None:
     confinement_1 = test_instance.aux_search_confinement({1}, {0})
     assert confinement_1 is not None
     assert confinement_1.node == 1
-    assert confinement_1.set_diff == {2}
+    assert confinement_1.set_diff == set({2})
 
     confinement_2 = test_instance.aux_search_confinement({1}, {0, 2})
     assert confinement_2 is None
@@ -218,7 +218,7 @@ def test_aux_search_confinement() -> None:
     confinement_4 = test_instance_2.aux_search_confinement({1}, {0})
     assert confinement_4 is not None
     assert confinement_4.node == 1
-    assert confinement_4.set_diff == {2, 3}
+    assert confinement_4.set_diff == set({2, 3})
 
 
 def test_apply_rule_unconfined() -> None:
@@ -226,7 +226,7 @@ def test_apply_rule_unconfined() -> None:
     weighting = Weighting.UNWEIGHTED
     test_instance = ker.UnweightedKernelization(SolverConfig(weighting=weighting), graph=P_3)
     test_instance.apply_rule_unconfined(2)
-    assert set(test_instance.kernel.nodes) == {0, 1}
+    assert frozenset(test_instance.kernel.nodes) == frozenset({0, 1})
 
 
 def test_unconfined_loop() -> None:
@@ -246,7 +246,7 @@ def test_search_rule_unconfined_and_diamond() -> None:
     weighting = Weighting.UNWEIGHTED
     test_instance = ker.UnweightedKernelization(SolverConfig(weighting=weighting), graph=K3_CLAW)
     test_instance.search_rule_unconfined_and_diamond()
-    assert set(test_instance.kernel) == {2, 4, 5}
+    assert frozenset(test_instance.kernel) == frozenset({2, 4, 5})
 
 
 @pytest.mark.parametrize("weighting", [Weighting.UNWEIGHTED, Weighting.WEIGHTED])
@@ -257,8 +257,8 @@ def test_fold_twin_uw(weighting: Weighting) -> None:
     test_instance.fold_twin(0, 1, 10, [2, 3, 4])
     assert not all(test_instance.kernel.has_node(node) for node in [0, 1, 2, 3, 4])
     assert all(test_instance.kernel.has_node(node) for node in [10, 5, 6])
-    N_v_prime = set(test_instance.kernel.neighbors(10))
-    assert N_v_prime == {5, 6}
+    N_v_prime = frozenset(test_instance.kernel.neighbors(10))
+    assert N_v_prime == frozenset({5, 6})
 
 
 @pytest.mark.parametrize("weighting", [Weighting.UNWEIGHTED, Weighting.WEIGHTED])
@@ -281,11 +281,11 @@ def test_apply_rule_twin_ind(weighting: Weighting) -> None:
         SolverConfig(weighting=weighting), graph=K23_CLAW_bis
     )._kernelizer
     test_instance.apply_rule_twin_independent(0, 1, [2, 3, 4])
-    assert set(test_instance.kernel.nodes()) == {5, 6, 7}
-    mis_1 = test_instance.rebuild({7})
-    assert mis_1 == {2, 3, 4}
-    mis_2 = test_instance.rebuild(set())
-    assert mis_2 == {0, 1}
+    assert frozenset(test_instance.kernel.nodes()) == frozenset({5, 6, 7})
+    mis_1 = test_instance.rebuild(frozenset({7}))
+    assert mis_1 == [frozenset({2, 3, 4})]
+    mis_2 = test_instance.rebuild(frozenset())
+    assert mis_2 == [frozenset({0, 1})]
 
 
 @pytest.mark.parametrize("weighting", [Weighting.UNWEIGHTED, Weighting.WEIGHTED])
@@ -294,9 +294,9 @@ def test_apply_rule_twin_not_ind(weighting: Weighting) -> None:
         SolverConfig(weighting=weighting), graph=K23_CLAW_N_linked
     )._kernelizer
     test_instance.apply_rule_twins_in_solution(0, 1, [2, 3, 4])
-    assert set(test_instance.kernel.nodes()) == {5, 6}
-    mis_1 = test_instance.rebuild(set())
-    assert mis_1 == {0, 1}
+    assert frozenset(test_instance.kernel.nodes()) == frozenset({5, 6})
+    mis_1 = test_instance.rebuild(frozenset())
+    assert mis_1 == [frozenset({0, 1})]
 
 
 @pytest.mark.parametrize("weighting", [Weighting.UNWEIGHTED, Weighting.WEIGHTED])
@@ -305,15 +305,15 @@ def test_search_rule_twin_reduction(weighting: Weighting) -> None:
         SolverConfig(weighting=weighting), graph=K23_CLAW_bis
     )._kernelizer
     test_instance.search_rule_twin_reduction()
-    assert set(test_instance.kernel.nodes()) == {5, 6, 7}
-    mis_1 = test_instance.rebuild({7})
-    assert mis_1 == {2, 3, 4}
-    mis_2 = test_instance.rebuild(set())
-    assert mis_2 == {0, 1}
+    assert frozenset(test_instance.kernel.nodes()) == frozenset({5, 6, 7})
+    mis_1 = test_instance.rebuild(frozenset({7}))
+    assert mis_1 == [frozenset({2, 3, 4})]
+    mis_2 = test_instance.rebuild(frozenset())
+    assert mis_2 == [frozenset({0, 1})]
     test_instance_2 = ker.Kernelization(
         SolverConfig(weighting=weighting), graph=K23_CLAW_N_linked
     )._kernelizer
     test_instance_2.apply_rule_twins_in_solution(0, 1, [2, 3, 4])
-    assert set(test_instance_2.kernel.nodes()) == {5, 6}
-    mis_3 = test_instance_2.rebuild(set())
-    assert mis_3 == {0, 1}
+    assert frozenset(test_instance_2.kernel.nodes()) == frozenset({5, 6})
+    mis_3 = test_instance_2.rebuild(frozenset())
+    assert mis_3 == [frozenset({0, 1})]

--- a/tests/test_qutip_mis.py
+++ b/tests/test_qutip_mis.py
@@ -30,6 +30,7 @@ def test_empty_qtip_mis(
         preprocessor=preprocessor,
         postprocessor=postprocessor,
         weighting=weighting,
+        max_number_of_solutions=10,
     )
 
     # Create the MIS instance
@@ -71,6 +72,7 @@ def test_disconnected_qtip_mis(
         preprocessor=preprocessor,
         postprocessor=postprocessor,
         weighting=weighting,
+        max_number_of_solutions=10,
     )
 
     # Create the MIS instance
@@ -123,6 +125,7 @@ def test_star_qtip_mis(
         preprocessor=preprocessor,
         postprocessor=postprocessor,
         weighting=weighting,
+        max_number_of_solutions=10,
     )
 
     # Create the MIS instance


### PR DESCRIPTION
Issue #135 is caused by the fact that rebuilders only ever return a single solution, even if more than one is possible.

This PR does not solve the entire problem, but rewrites the mechanism of rebuilders to make it possible to return more than one solution. It will require a followup to actually return the solutions in rebuilders that could hide more than one solution.