### PR TITLE
[Fix] Isolated node removal doesn't eat solutions anymore - resolves …

### DIFF
--- a/mis/pipeline/config.py
+++ b/mis/pipeline/config.py
@@ -111,7 +111,7 @@ class SolverConfig:
     max_iterations (int): Maximum number of iterations allowed for solving.
     """
 
-    max_number_of_solutions: int = 1
+    max_number_of_solutions: int = 10
     """
     A maximal number of solutions to return.
 

--- a/mis/pipeline/kernelization.py
+++ b/mis/pipeline/kernelization.py
@@ -1,4 +1,5 @@
 import abc
+import copy
 from dataclasses import dataclass
 from enum import Enum
 import logging
@@ -282,11 +283,9 @@ class BaseKernelization(BasePreprocessor, abc.ABC):
         Arguments:
             isolated An isolated node. We do not re-check that it is isolated.
         """
-        neighborhood = list(self.kernel.neighbors(isolated))
-        higher = self.get_nodes_with_strictly_higher_weight(isolated, neighborhood)
-        rule_app = RebuilderIsolatedNodeRemoval(isolated, higher)
+        rule_app = RebuilderIsolatedNodeRemoval(kernelization=self, isolated=isolated)
         self.add_rebuilder(rule_app)
-        self.kernel.remove_nodes_from(neighborhood)
+        self.kernel.remove_nodes_from(list(self.kernel.neighbors(isolated)))
         self.kernel.remove_node(isolated)
 
     def search_rule_isolated_node_removal(self) -> None:
@@ -882,15 +881,29 @@ class BaseRebuilder(abc.ABC):
 
 
 class RebuilderIsolatedNodeRemoval(BaseRebuilder):
-    def __init__(self, isolated: int, higher: list[int]):
+    def __init__(self, kernelization: BaseKernelization, isolated: int):
         self.isolated = isolated
-        self.higher = frozenset(higher)
+        self.snapshot = copy.deepcopy(kernelization)
 
     def rebuild(self, partial_solution: frozenset[int]) -> list[frozenset[int]]:
-        if len(partial_solution & self.higher) == 0:
-            return [partial_solution.union([self.isolated])]
-        else:
-            return [partial_solution]
+        # Any node in the clique could be part of a larger solution.
+        clique: frozenset[int] = frozenset(self.snapshot.kernel.neighbors(self.isolated)).union(
+            [self.isolated]
+        )
+
+        larger_solutions = []
+        for node in clique:
+            neighbours = frozenset(self.snapshot.kernel.neighbors(node))
+            if not neighbours.issubset(clique):
+                continue
+            higher = frozenset(
+                self.snapshot.get_nodes_with_strictly_higher_weight(node, neighbours)
+            )
+            if len(partial_solution & higher) == 0:
+                larger_solutions.append(partial_solution.union([node]))
+        if len(larger_solutions) == 0:
+            larger_solutions = [partial_solution]
+        return larger_solutions
 
 
 class RebuilderNodeFolding(BaseRebuilder):

--- a/mis/pipeline/kernelization.py
+++ b/mis/pipeline/kernelization.py
@@ -1,5 +1,4 @@
 import abc
-import copy
 from dataclasses import dataclass
 from enum import Enum
 import logging
@@ -895,7 +894,7 @@ class RebuilderIsolatedNodeRemoval(BaseRebuilder):
               rebuilder.
         """
         self.isolated = isolated
-        self.snapshot = copy.deepcopy(kernelization)
+        self.snapshot = kernelization.kernel.copy()
 
     def rebuild(self, partial_solution: frozenset[int]) -> list[frozenset[int]]:
         """
@@ -906,13 +905,13 @@ class RebuilderIsolatedNodeRemoval(BaseRebuilder):
         see e.g. issue #135.
         """
         # Any node in the clique could be part of a larger solution.
-        clique: frozenset[int] = frozenset(self.snapshot.kernel.neighbors(self.isolated)).union(
+        clique: frozenset[int] = frozenset(self.snapshot.neighbors(self.isolated)).union(
             [self.isolated]
         )
 
         larger_solutions = []
         for node in clique:
-            neighbours = frozenset(self.snapshot.kernel.neighbors(node))
+            neighbours = frozenset(self.snapshot.neighbors(node))
             if not neighbours.issubset(clique):
                 continue
             larger_solutions.append(partial_solution.union([node]))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,7 @@
 import networkx as nx
+import pytest
+
+from mis import MISInstance
 
 
 def empty_graph() -> nx.Graph:
@@ -17,3 +20,24 @@ def simple_graph() -> nx.Graph:
 
 def complex_graph() -> nx.Graph:
     return nx.erdos_renyi_graph(n=30, p=0.4, seed=42)
+
+
+@pytest.fixture
+def python_dependency_graph() -> MISInstance:
+    """
+    Reproducing the example for issues 116, 135, 136.
+    """
+    PYTHON_VERSIONS = ["Python 3.9", "Python 3.10", "Python 3.11", "Python 3.12", "Python 3.13"]
+    graph = nx.Graph()
+    graph.add_nodes_from(PYTHON_VERSIONS)
+    graph.add_nodes_from(["mygreatlib", "anotherlib"])
+
+    for i, v in enumerate(PYTHON_VERSIONS):
+        for w in PYTHON_VERSIONS[i + 1 :]:
+            graph.add_edge(v, w)
+
+    graph.add_edge("mygreatlib", "Python 3.11")
+    graph.add_edge("mygreatlib", "Python 3.12")
+    graph.add_edge("anotherlib", "Python 3.9")
+    graph.add_edge("anotherlib", "Python 3.12")
+    return MISInstance(graph)

--- a/tests/test_maximization.py
+++ b/tests/test_maximization.py
@@ -5,29 +5,9 @@ from mis.pipeline.maximization import Maximization
 from mis.shared.types import MISSolution
 
 
-def python_dependency_graph() -> MISInstance:
-    """
-    Reproducing the example for issue 116.
-    """
-    PYTHON_VERSIONS = ["Python 3.9", "Python 3.10", "Python 3.11", "Python 3.12", "Python 3.13"]
-    graph = nx.Graph()
-    graph.add_nodes_from(PYTHON_VERSIONS)
-    graph.add_nodes_from(["mygreatlib", "anotherlib"])
-
-    for i, v in enumerate(PYTHON_VERSIONS):
-        for w in PYTHON_VERSIONS[i + 1 :]:
-            graph.add_edge(v, w)
-
-    graph.add_edge("mygreatlib", "Python 3.11")
-    graph.add_edge("mygreatlib", "Python 3.12")
-    graph.add_edge("anotherlib", "Python 3.9")
-    graph.add_edge("anotherlib", "Python 3.12")
-    return MISInstance(graph)
-
-
-def test_independence() -> None:
+def test_independence(python_dependency_graph: MISInstance) -> None:
     """Testing that independent solutions are marked as independent and dependent solutions are turned independent"""
-    instance = python_dependency_graph()
+    instance = python_dependency_graph
     maximizer = Maximization(SolverConfig())
 
     incomplete_solution = MISSolution(


### PR DESCRIPTION
…#135

While there may be other cases in which the preprocessor eats solutions, so far, this is the only one we managed to detect.

This replaces #130 with an approach that requires fewer quantum resources.
